### PR TITLE
fix(error): remove unused useEffect for error logging in development

### DIFF
--- a/apps/web/src/app/(app)/(public)/(feed)/(post)/post/[id]/error.tsx
+++ b/apps/web/src/app/(app)/(public)/(feed)/(post)/post/[id]/error.tsx
@@ -2,7 +2,6 @@
 
 import { AlertCircle, ArrowLeft, Home, RefreshCw, Search } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
 import { Button } from '~/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card'
 
@@ -13,13 +12,6 @@ interface PostErrorProps {
 
 export default function PostError({ error, reset }: PostErrorProps) {
   const router = useRouter()
-
-  useEffect(() => {
-    // Log error for debugging in development
-    if (process.env.NODE_ENV === 'development') {
-      console.error('Post page error:', error)
-    }
-  }, [error])
 
   // Handle post not found
   if (error.name === 'NotFoundError' && error.message.includes('Post')) {

--- a/apps/web/src/app/(app)/error.tsx
+++ b/apps/web/src/app/(app)/error.tsx
@@ -2,7 +2,6 @@
 
 import { AlertCircle, Home, RefreshCw } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
 import { Button } from '~/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card'
 
@@ -13,13 +12,6 @@ interface ErrorProps {
 
 export default function DefaultError({ error, reset }: ErrorProps) {
   const router = useRouter()
-
-  useEffect(() => {
-    // Log error for debugging in development
-    if (process.env.NODE_ENV === 'development') {
-      console.error('Page error:', error)
-    }
-  }, [error])
 
   // Handle authentication errors
   if (error.name === 'UnauthenticatedError') {


### PR DESCRIPTION
This pull request removes development-only error logging from the error boundary components in the app. The changes simplify the error handling logic by eliminating the use of `useEffect` to log errors in development mode.

Error handling simplification:

* Removed the `useEffect` hook that logged errors to the console in development mode from `apps/web/src/app/(app)/(public)/(feed)/(post)/post/[id]/error.tsx` and `apps/web/src/app/(app)/error.tsx`. ([apps/web/src/app/(app)/(public)/(feed)/(post)/post/[id]/error.tsxL5](diffhunk://#diff-a558962c2e760a9fef8d9ebc92a29dd937211b67de3d5e9b92311540f8f28e03L5), [apps/web/src/app/(app)/(public)/(feed)/(post)/post/[id]/error.tsxL17-L23](diffhunk://#diff-a558962c2e760a9fef8d9ebc92a29dd937211b67de3d5e9b92311540f8f28e03L17-L23), [[1]](diffhunk://#diff-e85a471df705f3b24e8ea298e23f682d0aed73de509c2f697df7d8fb03f57798L5) [[2]](diffhunk://#diff-e85a471df705f3b24e8ea298e23f682d0aed73de509c2f697df7d8fb03f57798L17-L23)